### PR TITLE
EISW-48864 - OpenCV linux download error - missing package

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -177,7 +177,7 @@ endif()
 ## OpenCV
 if(ENABLE_OPENCV)
     reset_deps_cache(OpenCV_DIR)
-    
+
     set(OPENCV_VERSION "4.5.5")
     set(OPENCV_BUILD "131")
     set(OPENCV_BUILD_YOCTO "772")

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -93,6 +93,7 @@ if(THREADING STREQUAL "OMP")
 endif()
 
 ## TBB package
+# Fix downloading TBB package while using OpenCV package from third party server
 set(THIRDPARTY_SERVER_PATH "https://download.01.org/opencv/master/openvinotoolkit")
 if(THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO")
     reset_deps_cache(TBBROOT TBB_DIR)
@@ -179,10 +180,18 @@ if(ENABLE_OPENCV)
     reset_deps_cache(OpenCV_DIR)
 
     set(OPENCV_VERSION "4.5.5")
+    # This build apply only to linux package
     set(OPENCV_BUILD "131")
     set(OPENCV_BUILD_YOCTO "772")
 
     if(AARCH64)
+        # if(DEFINED ENV{THIRDPARTY_SERVER_PATH})
+        #     set(IE_PATH_TO_DEPS "$ENV{THIRDPARTY_SERVER_PATH}")
+        # elseif(DEFINED THIRDPARTY_SERVER_PATH)
+        #     set(IE_PATH_TO_DEPS "${THIRDPARTY_SERVER_PATH}")
+        # else()
+        #     message(WARNING "OpenCV is not found!")
+        # endif()
 
         if(DEFINED IE_PATH_TO_DEPS)
             set(OPENCV_SUFFIX "yocto_kmb")
@@ -200,6 +209,7 @@ if(ENABLE_OPENCV)
     else()
         if(WIN32 AND X86_64)
             RESOLVE_DEPENDENCY(OPENCV
+                    # Hardcoded build number for windows package
                     ARCHIVE_WIN "opencv/opencv_${OPENCV_VERSION}-099.txz"
                     TARGET_PATH "${TEMP}/opencv_${OPENCV_VERSION}/opencv"
                     ENVIRONMENT "OpenCV_DIR"

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -176,9 +176,10 @@ endif()
 ## OpenCV
 if(ENABLE_OPENCV)
     reset_deps_cache(OpenCV_DIR)
-
+    
+    set(IE_PATH_TO_DEPS "http://releases.ti.intel.com/Temp/opencv")
     set(OPENCV_VERSION "4.5.5")
-    set(OPENCV_BUILD "099")
+    set(OPENCV_BUILD "131")
     set(OPENCV_BUILD_YOCTO "772")
 
     if(AARCH64)
@@ -237,16 +238,16 @@ if(ENABLE_OPENCV)
                 set(OPENCV_HASH "cd46831b4d8d1c0891d8d22ff5b2670d0a465a8a8285243059659a50ceeae2c3")
             elseif(LINUX_OS_NAME STREQUAL "Ubuntu 18.04" AND X86_64)
                 set(OPENCV_SUFFIX "ubuntu18")
-                set(OPENCV_HASH "db087dfd412eedb8161636ec083ada85ff278109948d1d62a06b0f52e1f04202")
+                set(OPENCV_HASH "07b72209440bf2140d4a58d496ffc35bb4488e7bca231bdc04c335a495006421")
             elseif((LINUX_OS_NAME STREQUAL "Ubuntu 20.04" OR LINUX_OS_NAME STREQUAL "LinuxMint 20.1") AND X86_64)
                 set(OPENCV_SUFFIX "ubuntu20")
-                set(OPENCV_HASH "2fe7bbc40e1186eb8d099822038cae2821abf617ac7a16fadf98f377c723e268")
+                set(OPENCV_HASH "07b72209440bf2140d4a58d496ffc35bb4488e7bca231bdc04c335a495006421")
             elseif(NOT DEFINED OpenCV_DIR AND NOT DEFINED ENV{OpenCV_DIR})
                 message(FATAL_ERROR "OpenCV is not available on current platform (${LINUX_OS_NAME})")
             endif()
             RESOLVE_DEPENDENCY(OPENCV
-                    ARCHIVE_LIN "opencv/opencv_${OPENCV_VERSION}-${OPENCV_BUILD}_${OPENCV_SUFFIX}.txz"
-                    TARGET_PATH "${TEMP}/opencv_${OPENCV_VERSION}_${OPENCV_SUFFIX}/opencv"
+                    ARCHIVE_LIN "opencv/opencv_${OPENCV_VERSION}-${OPENCV_BUILD}.txz"
+                    TARGET_PATH "${TEMP}/opencv_${OPENCV_VERSION}/opencv"
                     ENVIRONMENT "OpenCV_DIR"
                     VERSION_REGEX ".*_([0-9]+.[0-9]+.[0-9]+).*"
                     SHA256 ${OPENCV_HASH})

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -178,7 +178,6 @@ endif()
 if(ENABLE_OPENCV)
     reset_deps_cache(OpenCV_DIR)
     
-    set(IE_PATH_TO_DEPS "http://releases.ti.intel.com/Temp/opencv")
     set(OPENCV_VERSION "4.5.5")
     set(OPENCV_BUILD "131")
     set(OPENCV_BUILD_YOCTO "772")

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -93,6 +93,7 @@ if(THREADING STREQUAL "OMP")
 endif()
 
 ## TBB package
+set(THIRDPARTY_SERVER_PATH "https://download.01.org/opencv/master/openvinotoolkit")
 if(THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO")
     reset_deps_cache(TBBROOT TBB_DIR)
 
@@ -183,13 +184,6 @@ if(ENABLE_OPENCV)
     set(OPENCV_BUILD_YOCTO "772")
 
     if(AARCH64)
-        if(DEFINED ENV{THIRDPARTY_SERVER_PATH})
-            set(IE_PATH_TO_DEPS "$ENV{THIRDPARTY_SERVER_PATH}")
-        elseif(DEFINED THIRDPARTY_SERVER_PATH)
-            set(IE_PATH_TO_DEPS "${THIRDPARTY_SERVER_PATH}")
-        else()
-            message(WARNING "OpenCV is not found!")
-        endif()
 
         if(DEFINED IE_PATH_TO_DEPS)
             set(OPENCV_SUFFIX "yocto_kmb")

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -200,7 +200,7 @@ if(ENABLE_OPENCV)
     else()
         if(WIN32 AND X86_64)
             RESOLVE_DEPENDENCY(OPENCV
-                    ARCHIVE_WIN "opencv/opencv_${OPENCV_VERSION}-${OPENCV_BUILD}.txz"
+                    ARCHIVE_WIN "opencv/opencv_${OPENCV_VERSION}-099.txz"
                     TARGET_PATH "${TEMP}/opencv_${OPENCV_VERSION}/opencv"
                     ENVIRONMENT "OpenCV_DIR"
                     VERSION_REGEX ".*_([0-9]+.[0-9]+.[0-9]+).*"


### PR DESCRIPTION
There was a problem with downloading ocv package on linux build. Below PR fix mentioned issue.
set IE_PATH_TO_DEPS="http://releases.ti.intel.com/Releases/opencv" if needed to build linux package

Linux job: https://vpu-validation-ci-icv.ir.intel.com/job/Utils/job/Build_VPUX_Plugin/job/Linux/81/
Windows job: https://vpu-validation-ci-icv.ir.intel.com/job/Utils/job/Build_VPUX_Plugin/job/Windows/25/